### PR TITLE
Bump sse4_crc32 to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/componentjs/builder-coffee/issues"
   },
   "dependencies": {
-    "sse4_crc32": "^2.1.2",
+    "sse4_crc32": "^3.1.0",
     "coffee-script": "^1.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Allows compilation on newer versions of v8
The only backwards incompatible change is to .update, which this project doesn't use
https://github.com/Voxer/sse4_crc32/releases
